### PR TITLE
Disable git safe.directory for the image

### DIFF
--- a/sles15/Dockerfile.amd64
+++ b/sles15/Dockerfile.amd64
@@ -14,3 +14,6 @@ RUN zypper --non-interactive update && \
     && \
     # cleanup to ensure we don't leave behind anything that doesn't need to be in the image
     zypper --non-interactive clean -a
+
+# the code is checked out on the host so the user will be different
+RUN git config --global --add safe.directory '*'


### PR DESCRIPTION
This fixes:
```
Craft               : /github/home/craft/CraftMaster/linux-64-gcc
Version             : master
ABI                 : linux-gcc-x86_64
Download directory  : /github/home/craft/CraftMaster/downloads
executing command: /opt/microsoft/powershell/7/pwsh /__w/client/client/.github/workflows/.run-clang-tidy.ps1
fatal: detected dubious ownership in repository at '/__w/client/client'
To add an exception for this directory, call:

	git config --global --add safe.directory /__w/client/client